### PR TITLE
Workspace: No catalogue subfolders

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For both `tng-workspace` and `tng-project` the option `--debug` makes the output
 
 ## Documentation
 
-* [Documentation of SONATA's son-workspace](https://github.com/sonata-nfv/son-cli/wiki/son%E2%80%90workspace)
+See the [wiki](https://github.com/sonata-nfv/tng-sdk-project/wiki) for further documentation and details.
 
 ## Development
 

--- a/src/tngsdk/project/workspace.py
+++ b/src/tngsdk/project/workspace.py
@@ -177,8 +177,6 @@ class Workspace:
         os.makedirs(self.workspace_root, exist_ok=False)
 
         dirs = [self.config['catalogues_dir'],
-                os.path.join(self.config['catalogues_dir'], 'ns_catalogue'),
-                os.path.join(self.config['catalogues_dir'], 'vnf_catalogue'),
                 self.config['configuration_dir'],
                 self.config['platforms_dir'],
                 self.config['projects_dir'],


### PR DESCRIPTION
No more ns_catalogues and vnf_catalogues subfolders. They aren't needed.