### PR TITLE
Fixed Windows paths

### DIFF
--- a/int-sdk-project-package/test.sh
+++ b/int-sdk-project-package/test.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -e
 
+# install required packages
+apt-get install -y git python3 python3-setuptools
+    
+# install tng-sdk-project
+git clone https://github.com/sonata-nfv/tng-sdk-project.git
+cd tng-sdk-project && python3 setup.py develop & cd ..
+
+# install tng-sdk-package
+git clone https://github.com/sonata-nfv/tng-sdk-package.git
+cd tng-sdk-package && python3 setup.py install & cd ..
+
 # create a workspace
 printf "Configuring workspace"
 tng-workspace
@@ -13,10 +24,19 @@ tng-project -p p1
 printf "Create and add test file"
 echo "test text file" > p1/test.txt
 tng-project -p p1 --add p1/test.txt
+tng-project -p p1 --status
 
-# package the project (currently fails since packaging is not yet implemented)
+# package the project
 printf "Package the project"
 tng-package -p p1
 
-# TODO: check created package
+# unpackage the project again and check its status
+printf "Unpackage the project"
+tng-package -u eu.5gtango.5gtango-project-sample.0.1.tgo
+tng-project -p eu.5gtango.5gtango-project-sample.0.1 --status
 
+# test packaging and unpackaging of tng-schema examples
+git clone https://github.com/sonata-nfv/tng-schema.git
+cd tng-schema/package-specification/
+tng-package -p example-projects/5gtango-ns-project-example
+tng-package -u example-projects/eu.5gtango.ns-package-example.0.1.tgo

--- a/src/tngsdk/project/project.py
+++ b/src/tngsdk/project/project.py
@@ -220,6 +220,10 @@ class Project:
         abs_file_path = os.path.abspath(file_path)
         abs_prj_root = os.path.abspath(self._prj_root)
         rel_file_path = os.path.relpath(abs_file_path, abs_prj_root)
+        # fix windows paths by replacing \ with /
+        if os.name == 'nt':
+            rel_file_path = rel_file_path.replace('\\', '/')
+            log.debug('Adjusted Windows path in project.yml: {}'.format(rel_file_path))
 
         # add to project.yml
         file = {'path': rel_file_path, 'type': type, 'tags': ['eu.5gtango']}


### PR DESCRIPTION
Before, projects greated on Windows had typical backslashes (\) in the file paths within `project.yml`. This leads to errors when packaging and later on. Now fixed to always use "/" instead.

Closes #32 