### PR TITLE
CI: Try to run the packager tests as downstream job to always test the

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,9 @@ pipeline {
         }
         stage('Integration tests (SDK-tools)')
         {
-            build job: "tng-sdk-package-pipeline" 
+            steps {
+                build job: "tng-sdk-package-pipeline"
+            }
         }
         stage('Container publication') {
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,13 @@ pipeline {
                 sh "pipeline/checkstyle/check.sh"
             }
         }
+        stage('Integration tests (SDK-tools)')
+        {
+            steps {
+                echo 'Stage: Integration tests agains other SDK tools...'
+                build job "tng-sdk-package-pipeline"
+            }
+        }
         stage('Container publication') {
             steps {
                 echo 'Stage: Container publication...'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,10 +29,7 @@ pipeline {
         }
         stage('Integration tests (SDK-tools)')
         {
-            steps {
-                echo 'Stage: Integration tests agains other SDK tools...'
-                build job "tng-sdk-package-pipeline"
-            }
+            build job "tng-sdk-package-pipeline" 
         }
         stage('Container publication') {
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
         }
         stage('Integration tests (SDK-tools)')
         {
-            build job "tng-sdk-package-pipeline" 
+            build job: "tng-sdk-package-pipeline" 
         }
         stage('Container publication') {
             steps {


### PR DESCRIPTION
integeration between SDK tools.

Signed-off-by: peusterm <manuel.peuster@uni-paderborn.de>