### PR TITLE
If a user wants to use the default workspace dir, and the dir does not

### DIFF
--- a/src/tngsdk/project/workspace.py
+++ b/src/tngsdk/project/workspace.py
@@ -235,9 +235,16 @@ class Workspace:
             ws_root = Workspace.DEFAULT_WORKSPACE_DIR
         ws_filename = os.path.join(ws_root, Workspace.__descriptor_name__)
         if not os.path.isdir(ws_root) or not os.path.isfile(ws_filename):
-            log.error("Unable to load workspace descriptor '{}'. "
-                      "Create workspace with tng-wks and specify location with -w".format(ws_filename))
-            return None
+            if ws_root == Workspace.DEFAULT_WORKSPACE_DIR:
+                # if we tried the default WS, and cannot find it,
+                # assume first execution of tng-sdk-project and just
+                # create the default WS
+                create_workspace(ws_root)
+            else:
+                log.error("Unable to load workspace descriptor '{}'. "
+                          "Create workspace with tng-wks and specify "
+                          + "location with -w".format(ws_filename))
+                return None
 
         ws_file = open(ws_filename, 'r')
         try:
@@ -423,8 +430,11 @@ def init_workspace(args=None):
 
     else:
         ws_root = os.path.expanduser(args.workspace)
+    create_workspace(ws_root, log_level)
 
-    # init workspace
+
+def create_workspace(ws_root, log_level="INFO"):
+    # create a new workspace
     ws = Workspace(ws_root, log_level=log_level)
     if ws.check_ws_exists():
         print("A workspace already exists at the specified location",

--- a/src/tngsdk/rest.py
+++ b/src/tngsdk/rest.py
@@ -356,7 +356,7 @@ class ProjectDownload(Resource):
         if not os.path.isdir(project_path):
             log.error("No project found with name/UUID {}".format(project_uuid))
             return {'error_msg': "Project not found: {}".format(project_uuid)}, 404
-        project = cli_project.load_project(project_path)
+        # project = cli_project.load_project(project_path)
 
         # zip the project
         zip_path = os.path.join('projects', project_uuid + '.zip')


### PR DESCRIPTION
yet exist, assume that we run for the first time and simply create it.

Signed-off-by: peusterm <manuel.peuster@uni-paderborn.de>