### PR TITLE
fix: require werkzeug>=0.15.1 to fix import

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ coloredlogs
 tabulate
 requests
 Flask>=0.10.1
-werkzeug
+werkzeug>=0.15.1
 flask-restplus


### PR DESCRIPTION
Closes #79 